### PR TITLE
Fix BUG: Repack error in nut mode

### DIFF
--- a/CDNSP-GUI-Bob.py
+++ b/CDNSP-GUI-Bob.py
@@ -336,6 +336,8 @@ def get_name(tid):
             if tid.endswith('800'):
                 tid = '%s000' % tid[:-3]
             name = title_list[titleID_list.index(tid.lower())]
+            #Check And Format Windows FileName Limit
+            name = re.sub(r'[/\\:*?!"|™©®()]+', "", unidecode.unidecode(name.strip()))
             print(name)
             return name
         except:


### PR DESCRIPTION
#Check And Format Windows FileName Limit
The filename which included '[\/:*?"<>|]' can't be repack when downloading finish.

Example: In Nut Mode, Title ID: 01000e2003fa1004
[DLC] MIGHTY GUNVOLT BURST [DLC Character Ray] [01000e2003fa1004][v0].nsp